### PR TITLE
Comment Update Implemented

### DIFF
--- a/toktik-frontend/src/components/VideoPlayer.vue
+++ b/toktik-frontend/src/components/VideoPlayer.vue
@@ -36,6 +36,11 @@ export default {
   mounted() {
     this.videoId = this.video;
     this.videoLoaded = false;
+    this.sockets.subscribe(`video-comment-${this.video}`, (data) => {
+      if ( data.user_id !== parseInt(localStorage.getItem("userId")) ) {
+        EventBus.$emit('update-comment', data)
+      }
+    });
     this.getVideo();
   },
   beforeDestroy() {
@@ -45,6 +50,7 @@ export default {
     if (this.player) {
       this.player.dispose();
     }
+    this.sockets.unsubscribe(`video-comment-${this.video}`)
   },
   methods: {
     async getVideo() {

--- a/toktik-frontend/src/components/VideoPopUp.vue
+++ b/toktik-frontend/src/components/VideoPopUp.vue
@@ -138,6 +138,10 @@ export default {
       this.showVideo = false;
       this.videoId = -1;
     });
+
+    EventBus.$on("update-comment", (payload) => {
+      this.appendComment(payload)
+    });
   },
   async mounted() {
     this.intervalId = setInterval(async () => {


### PR DESCRIPTION
- Can successfully receive the payload
- Dynamically subscribes and unsubscribes to the WS channel the belongs to a video's comment section
- Will prioritize read-your-write over WS updates:
   - if User1 writes a comment, they will also receive WS payload of their own comment
   - the frontend will check if the comment in the payload is of the same user id or not (won't append comment if same)
 